### PR TITLE
Set softtabstop=2

### DIFF
--- a/ftplugin/vader.vim
+++ b/ftplugin/vader.vim
@@ -23,7 +23,7 @@
 
 let b:vader_eos = '\(^.*\n\(^[^# ].*:\)\@=\)\|\%$'
 
-setlocal shiftwidth=2 tabstop=2 expandtab
+setlocal shiftwidth=2 tabstop=2 softtabstop=2 expandtab
 
 nnoremap <buffer><silent> [[ :call search('^[^# ]', 'bW')<CR>
 nnoremap <buffer><silent> [] :call search(b:vader_eos, 'bW')<CR>


### PR DESCRIPTION
If softtabstop is globally set to e.g. 4, expandtab will insert 4 spaces
when hitting tab in insert mode. Vader expects 2.
