### PR TITLE
Add SyntaxAt and SyntaxOf helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,19 @@ In Execute block, the following commands are provided.
     - `Save <name>[, ...]`
     - `Restore [<name>, ...]`
 
-And the path of the current .vader file can be accessed via `g:vader_file`.
+The following syntax helper functions are provided:
+
+-   `SyntaxAt`: return a string with the name of the syntax group at the following position:
+
+    - `SyntaxAt()`: current cursor position
+    - `SyntaxAt(col)`: current cursor line, at given column
+    - `SyntaxAt(lnum, col)`: line and column
+
+-   `SyntaxOf(pattern[, nth=1])`: return a string with the name of the syntax group
+    at the first character of the nth match of the given pattern.
+    Return `''` if there was no match.
+
+The path of the current `.vader` file can be accessed via `g:vader_file`.
 
 In addition to plain Vimscript, you can also test Ruby/Python/Perl/Lua interface
 with Execute block as follows:
@@ -219,6 +231,13 @@ Expect ruby (indented and shifted):
     def a
       a = 1
     end
+
+Given c (C file):
+  int i = 0;
+
+Execute (syntax is good):
+  AssertEqual SyntaxAt(2), 'cType'
+  AssertEqual SyntaxOf('0'), 'cNumber'
 ```
 
 Setting up isolated testing environment

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -150,6 +150,8 @@ function! s:prepare()
   command! -nargs=+ AssertEqual    :call vader#assert#equal(<args>)
   command! -nargs=+ AssertNotEqual :call vader#assert#not_equal(<args>)
   command! -nargs=+ AssertThrows   :call vader#assert#throws(<q-args>)
+  let g:SyntaxAt = function('vader#helper#syntax_at')
+  let g:SyntaxOf = function('vader#helper#syntax_of')
 endfunction
 
 function! s:cleanup()
@@ -161,6 +163,8 @@ function! s:cleanup()
   delcommand AssertEqual
   delcommand AssertNotEqual
   delcommand AssertThrows
+  unlet g:SyntaxAt
+  unlet g:SyntaxOf
 endfunction
 
 function! s:comment(case, label)

--- a/autoload/vader/helper.vim
+++ b/autoload/vader/helper.vim
@@ -1,0 +1,43 @@
+function! vader#helper#syntax_at(...)
+  if a:0 < 2
+    let l:pos = getpos('.')
+    let l:cur_lnum = pos[1]
+    let l:cur_col = pos[2]
+    if a:0 == 0
+      let l:lnum = l:cur_lnum
+      let l:col = l:cur_col
+    else
+      let l:lnum = l:cur_lnum
+      let l:col = a:1
+    endif
+  else
+    let l:lnum = a:1
+    let l:col = a:2
+  endif
+  return synIDattr(synID(l:lnum, l:col, 1), 'name')
+endfunction
+
+function! vader#helper#syntax_of(pattern, ...)
+  if a:0 < 1
+    let l:nth = 1
+  else
+    let l:nth = a:1
+  endif
+
+  let l:pos_init = getpos('.')
+  call cursor(1, 1)
+  let found = search(a:pattern, 'cW')
+  while found != 0 && nth > 1
+    let found = search(a:pattern, 'W')
+    let nth -= 1
+  endwhile
+
+  if found
+    let l:pos = getpos('.')
+    let l:output = vader#helper#syntax_at(l:pos[1], l:pos[2])
+  else
+    let l:output = ''
+  endif
+  call setpos('.', l:pos_init)
+  return l:output
+endfunction

--- a/test/feature/helper.vader
+++ b/test/feature/helper.vader
@@ -1,0 +1,46 @@
+Given c (C file):
+  int i = 0;
+  char c = 'i';
+
+Execute (SyntaxAt())):
+  call cursor(1, 1)
+  AssertEqual SyntaxAt(), 'cType'
+  call cursor(1, 9)
+  AssertEqual SyntaxAt(), 'cNumber'
+  call cursor(2, 1)
+  AssertEqual SyntaxAt(1), 'cType'
+  call cursor(2, 11)
+  AssertEqual SyntaxAt(11), 'cCharacter'
+
+Execute (SyntaxAt(col))):
+  call cursor(1, 1)
+  AssertEqual SyntaxAt(1), 'cType'
+  AssertEqual SyntaxAt(9), 'cNumber'
+  call cursor(2, 1)
+  AssertEqual SyntaxAt(1), 'cType'
+  AssertEqual SyntaxAt(11), 'cCharacter'
+
+Execute (SyntaxAt(lnum, col))):
+  AssertEqual SyntaxAt(1, 1), 'cType'
+  AssertEqual SyntaxAt(1, 9), 'cNumber'
+  AssertEqual SyntaxAt(2, 1), 'cType'
+  AssertEqual SyntaxAt(2, 11), 'cCharacter'
+
+Execute (SyntaxOf(pattern)):
+  AssertEqual SyntaxOf('i'), 'cType'
+  AssertEqual SyntaxOf('int'), 'cType'
+  AssertEqual SyntaxOf('int i = 0;'), 'cType'
+  AssertEqual SyntaxOf('0'), 'cNumber'
+  AssertEqual SyntaxOf('\(c = ''\)\@<=i'), 'cCharacter'
+
+Execute (SyntaxOf(pattern, count)):
+  AssertEqual SyntaxOf('i', 1), 'cType'
+  AssertEqual SyntaxOf('i', 3), 'cCharacter'
+  AssertEqual SyntaxOf('i', 4), ''
+
+Execute (SyntaxOf does not move cursor):
+  call cursor(2, 1)
+  AssertEqual SyntaxOf('0'), 'cNumber'
+  let pos = getpos('.')
+  AssertEqual pos[1], 2
+  AssertEqual pos[2], 1

--- a/test/vader.vader
+++ b/test/vader.vader
@@ -12,6 +12,7 @@ Include (Before/After):                  feature/before-after.vader
 Include (Save/Restore):                  feature/save-restore.vader
 Include (Testing Ruby/Python interface): feature/lang-if.vader
 Include (blocks w/o indentation):        feature/no-indentation.vader
+Include (Helpers):                       feature/helper.vader
 
 * Regressions
 Include (Macro set to linewise when it ends with <CR>): regression/characterwise-macro.vader


### PR DESCRIPTION
With this, even mere human beings can test syntax files. =)

The only thing I haven't done is document under `doc/`, only under `README.md`. At a quick look it seems like both are the same: are you manually doing things twice, or is there a better way?
