### PR TITLE
Add run-tests script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,5 @@ before_script: |
   cd -
 
 script: |
-  /usr/local/bin/vim -Nu <(cat << VIMRC
-  filetype off
-  set rtp+=.
-  filetype plugin indent on
-  syntax enable
-  VIMRC) -c 'Vader! test/*' > /dev/null
+  export PATH="/usr/local/bin:$PATH"
+  ./test/run-tests.sh

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd "$( dirname "${BASH_SOURCE[0]}" )" && vim -Nu vimrc -c 'Vader! *' > /dev/null

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,0 +1,4 @@
+filetype off
+set rtp+=../
+filetype plugin indent on
+syntax enable


### PR DESCRIPTION
- allows users to run tests with a clean vimrc with `cd test && ./run-tests.sh`. This is also how Vader should be used in projects.
- automatically reloads changes to the Vader plugin after you modify it: restarting the main Vim may be time consuming when you have a lot of plugins
- makes vimrc into a separate file, so we get syntax highlighting for it
