### PR TITLE
Add failing test for `gf`

### DIFF
--- a/test/regression/gf.vader
+++ b/test/regression/gf.vader
@@ -1,0 +1,9 @@
+Given:
+  vimrc
+
+Do(gf):
+  gf
+
+Execute(check):
+  Assert expand('%:t') == 'vimrc'
+  Assert getline('.') != 'vimrc', "Content has not been changed to Given."

--- a/test/vader.vader
+++ b/test/vader.vader
@@ -16,6 +16,7 @@ Include (Helpers):                       feature/helper.vader
 
 * Regressions
 Include (Macro set to linewise when it ends with <CR>): regression/characterwise-macro.vader
+Include (gf does not change buffer contents): regression/gf.vader
 
 Include: include/teardown.vader
 


### PR DESCRIPTION
Ref: https://github.com/junegunn/vader.vim/issues/30

```
% vim -Nu vimrc -c 'Vader! regression/gf.vader'
…
Starting Vader: 1 suite(s), 2 case(s)
  Starting Vader: …/vim/neobundles/vader/test/regression/gf.vader
    (1/2) [  GIVEN]
    (1/2) [     DO] gf
    (2/2) [  GIVEN]
    (2/2) [EXECUTE] check
    (2/2) [EXECUTE] (X) Content has not been changed to Given.
  Success/Total: 1/2
Success/Total: 1/2 (assertions: 1/2)
```
