### PR TITLE
doc: suggest setting HOME=/dev/null

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ the test. The simplest way to achieve this is to start Vim with a mini
 .vimrc as follows:
 
 ```sh
-vim -Nu <(cat << EOF
+HOME=/dev/null vim -Nu <(cat << EOF
 filetype off
 set rtp+=~/.vim/bundle/vader.vim
 set rtp+=~/.vim/bundle/vim-markdown
@@ -273,7 +273,7 @@ before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
 script: |
-  vim -Nu <(cat << VIMRC
+  HOME=/dev/null vim -Nu <(cat << VIMRC
   filetype off
   set rtp+=vader.vim
   set rtp+=.

--- a/doc/vader.txt
+++ b/doc/vader.txt
@@ -306,7 +306,7 @@ environment that is isolated from the other plugins and settings irrelevant to
 the test. The simplest way to achieve this is to start Vim with a mini .vimrc
 as follows:
 >
-    vim -Nu <(cat << EOF
+    HOME=/dev/null vim -Nu <(cat << EOF
     filetype off
     set rtp+=~/.vim/bundle/vader.vim
     set rtp+=~/.vim/bundle/vim-markdown
@@ -328,7 +328,7 @@ to your project root. For most plugins the following example should suffice.
       git clone https://github.com/junegunn/vader.vim.git
 
     script: |
-      vim -Nu <(cat << VIMRC
+      HOME=/dev/null vim -Nu <(cat << VIMRC
       filetype off
       set rtp+=vader.vim
       set rtp+=.


### PR DESCRIPTION
Otherwise Vim will use it in &runtimepath, which loads plugins from
~/.vim/plugin.

Instead of /dev/null $PWD or something else could be used, but then
`set viminfo=` should get suggested, too.

While at it, I think the docs should suggest using a `vimrc` file, instead of the `<(cat ..)` blob.
Plugin authors will use it like this, and it makes it more difficult to maintain, compared to using a `test/vimrc` file.
