### PR TITLE
Add `Then` block (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ spaces.
     - Normal-mode keystrokes that can span multiple lines
 - Execute
     - Vimscript to execute
+- Then
+    - Vimscript to run after Do or Execute block. Used for assertions.
 - Expect
     - Expected result of the preceding Do/Execute block
 - Before
@@ -126,6 +128,16 @@ Execute [lang] [(comment)]:
 
 See Ruby and Python examples
 [here](https://github.com/junegunn/vader.vim/blob/master/test/feature/lang-if.vader).
+
+#### Then
+
+A Then block containing Vimscript can follow a Do or an Execute block. Mostly
+used for assertions. Can be used in conjunction with an Expect block.
+
+```
+Then [(comment)]:
+  [vimscript]
+```
 
 #### Expect
 

--- a/autoload/vader/syntax.vim
+++ b/autoload/vader/syntax.vim
@@ -38,7 +38,7 @@ function! vader#syntax#include(l1, l2)
 endfunction
 
 function! vader#syntax#_head()
-  return '\(\(^\(Given\|Expect\|Do\|Execute\|Before\|After\)\(\s\+[^:;(]\+\)\?\s*\((.*)\)\?\s*[:;]\s*$\)\|\(^Include\(\s*(.*)\)\?\s*:\)\)\@='
+  return '\(\(^\(Given\|Expect\|Do\|Execute\|Then\|Before\|After\)\(\s\+[^:;(]\+\)\?\s*\((.*)\)\?\s*[:;]\s*$\)\|\(^Include\(\s*(.*)\)\?\s*:\)\)\@='
 endfunction
 
 function! s:load(type)

--- a/doc/vader.txt
+++ b/doc/vader.txt
@@ -1,10 +1,10 @@
-vader.txt	vader	Last change: December 13 2014
+vader.txt	vader	Last change: December 28 2014
 VADER - TABLE OF CONTENTS                                      *vader* *vader-toc*
 ==============================================================================
 
   vader.vim
-      Vader test cases                                           |vader-0-1|
-      Vader result                                               |vader-0-2|
+      Vader test cases
+      Vader result
     Installation                                                 |vader-1|
     Running Vader tests                                          |vader-2|
     Syntax of .vader file                                        |vader-3|
@@ -12,7 +12,8 @@ VADER - TABLE OF CONTENTS                                      *vader* *vader-to
         Given                                                    |vader-3-1-1|
         Do                                                       |vader-3-1-2|
         Execute                                                  |vader-3-1-3|
-        Expect                                                   |vader-3-1-4|
+        Then                                                     |vader-3-1-4|
+        Expect                                                   |vader-3-1-5|
       Hooks                                                      |vader-3-2|
         Before                                                   |vader-3-2-1|
         After                                                    |vader-3-2-2|
@@ -39,13 +40,13 @@ I use Vader to test Vimscript.
 
 < Vader test cases >__________________________________________________________~
                                                               *vader-test-cases*
-                                                                     *vader-0-1*
+
 https://raw.github.com/junegunn/i/master/vader.png
 
 
 < Vader result >______________________________________________________________~
                                                                   *vader-result*
-                                                                     *vader-0-2*
+
 https://raw.github.com/junegunn/i/master/vader-result.png
 
 
@@ -90,6 +91,8 @@ spaces.
    - Normal-mode keystrokes that can span multiple lines
  - Execute
    - Vimscript to execute
+ - Then
+   - Vimscript to run after Do or Execute block. Used for assertions.
  - Expect
    - Expected result of the preceding Do/Execute block
  - Before
@@ -182,9 +185,20 @@ See Ruby and Python examples {here}{2}.
 {2} https://github.com/junegunn/vader.vim/blob/master/test/feature/lang-if.vader
 
 
+Then~
+                                                                    *vader-then*
+                                                                   *vader-3-1-4*
+
+A Then block containing Vimscript can follow a Do or an Execute block. Mostly
+used for assertions. Can be used in conjunction with an Expect block.
+>
+    Then [(comment)]:
+      [vimscript]
+<
+
 Expect~
                                                                   *vader-expect*
-                                                                   *vader-3-1-4*
+                                                                   *vader-3-1-5*
 
 If an Expect block follows an Execute block or a Do block, the result of the
 preceding block is compared to the content of the Expect block. Comparison is

--- a/syntax/vader-result.vim
+++ b/syntax/vader-result.vim
@@ -33,9 +33,10 @@ syntax match vaderResultTitle2Rest /\(^  [^:]*:\)\@<=.*/ contains=vaderResultNum
 syntax match vaderResultNumber /-\?[0-9]\+\(\.[0-9]\+\)\?/ contained
 syntax match vaderResultItem /^    [^\]]\+\]\( (X).*\)\?/ contains=vaderResultSequence,vaderResultType,vaderResultError
 syntax match vaderResultSequence /^    ([0-9/ ]\+)/ contains=vaderResultNumber contained
-syntax match vaderResultType /\[[A-Z ]\+\]/ contained contains=vaderResultDo,vaderResultGiven,vaderResultExpect,vaderResultExecute,vaderResultBefore,vaderResultAfter
+syntax match vaderResultType /\[[A-Z ]\+\]/ contained contains=vaderResultDo,vaderResultThen,vaderResultGiven,vaderResultExpect,vaderResultExecute,vaderResultBefore,vaderResultAfter
 syntax match vaderResultDiff /^          .*/
 syntax match vaderResultDo /DO/ contained
+syntax match vaderResultThen /THEN/ contained
 syntax match vaderResultGiven /GIVEN/ contained
 syntax match vaderResultExpect /EXPECT/ contained
 syntax match vaderResultExecute /EXECUTE/ contained
@@ -57,6 +58,7 @@ hi def link vaderResultType Delimiter
 
 hi def link vaderResultGiven Include
 hi def link vaderResultDo PreProc
+hi def link vaderResultThen Conditional
 hi def link vaderResultBefore Special
 hi def link vaderResultAfter Special
 hi def link vaderResultExecute Statement

--- a/syntax/vader.vim
+++ b/syntax/vader.vim
@@ -52,6 +52,7 @@ syn cluster vaderIgnored contains=vaderComment,vaderSepCaret,vaderSepTilde,vader
 syn region vaderGiven   start=/^Given\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderText,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderExpect  start=/^Expect\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderText,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderDo      start=/^Do\(\s*(.*)\)\?\s*:\s*$/      end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
+syn region vaderThen    start=/^Then\(\s*(.*)\)\?\s*:\s*$/    end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderExecute start=/^Execute\(\s*(.*)\)\?\s*:\s*$/ end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderBefore  start=/^Before\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderAfter   start=/^After\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
@@ -59,12 +60,13 @@ syn region vaderAfter   start=/^After\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-
 execute printf('syn region vaderGivenRaw   start=/^Given\(\s*(.*)\)\?\s*;\s*$/   end=/%s/ contains=vaderMessage,vaderTextRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderExpectRaw  start=/^Expect\(\s*(.*)\)\?\s*;\s*$/  end=/%s/ contains=vaderMessage,vaderTextRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderDoRaw      start=/^Do\(\s*(.*)\)\?\s*;\s*$/      end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
+execute printf('syn region vaderThenRaw    start=/^Then\(\s*(.*)\)\?\s*;\s*$/    end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderExecuteRaw start=/^Execute\(\s*(.*)\)\?\s*;\s*$/ end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderBeforeRaw  start=/^Before\(\s*(.*)\)\?\s*;\s*$/  end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderAfterRaw   start=/^After\(\s*(.*)\)\?\s*;\s*$/   end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 
 syn match vaderInclude /^Include\(\s*(.*)\)\?\s*:/ contains=vaderMessage
-syn cluster vaderTopLevel contains=vaderGiven,vaderExpect,vaderDo,vaderExpect,vaderBefore,vaderAfter,vaderExpectRaw,vaderDoRaw,vaderExpectRaw,vaderBeforeRaw,vaderAfterRaw,vaderInclude
+syn cluster vaderTopLevel contains=vaderGiven,vaderExpect,vaderDo,vaderText,vaderExpect,vaderBefore,vaderAfter,vaderExpectRaw,vaderDoRaw,vaderThenRaw,vaderExpectRaw,vaderBeforeRaw,vaderAfterRaw,vaderInclude
 
 syn keyword Todo TODO FIXME XXX TBD
 
@@ -77,6 +79,8 @@ hi def link vaderAfter       Special
 hi def link vaderAfterRaw    Special
 hi def link vaderDo          PreProc
 hi def link vaderDoRaw       PreProc
+hi def link vaderThen        Conditional
+hi def link vaderThenRaw     Conditional
 hi def link vaderExecute     Statement
 hi def link vaderExecuteRaw  Statement
 hi def link vaderExecuteType Identifier

--- a/test/feature/suite1.vader
+++ b/test/feature/suite1.vader
@@ -35,6 +35,8 @@ Expect ruby (Expect block content should match the result of previous Do block):
     a = 1
   end
 
+Do (FIXME: Nothing):
+
 Expect ruby (Previous Given block is repeated, thus this should fail):
   def b
     a = 1


### PR DESCRIPTION
```
Given (Some text):
  Something

Do (Convert it to lowercase and yank the word):
  ye
  guu

Then (@" register should hold the original word):
  AssertEqual 'Something', @"

Expect (But the buffer should contain text in lowercase):
  something
```

Can be used to replace hacky use of After blocks;
e.g. https://github.com/junegunn/vim-oblique/blob/9d11d2/test/oblique.vader#L6-L12
