### PR TITLE
Add support for VADER_OUTPUT_FILE instead of stderr

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -122,10 +122,15 @@ function! vader#run(bang, ...) range
 endfunction
 
 function! s:print_stderr(output)
-  let tmp = tempname()
-  call writefile(split(a:output, '\n'), tmp)
-  execute 'silent !cat '.tmp.' 1>&2'
-  call delete(tmp)
+  let output_file = expand("$VADER_OUTPUT_FILE")
+  if len(output_file)
+    call writefile(split(a:output, '\n'), output_file, 'a')
+  else
+    let tmp = tempname()
+    call writefile(split(a:output, '\n'), tmp)
+    execute 'silent !cat '.tmp.' 1>&2'
+    call delete(tmp)
+  endif
 endfunction
 
 function! s:split_args(arg)


### PR DESCRIPTION
Since Neovim is not capable of writing to stderr (https://github.com/neovim/neovim/issues/4772), and writing to a
pre-defined file is useful in general, this patch adds support for
passing in VADER_OUTPUT_FILE through the environment.
If given, the output from `:Vader!` gets appended to this file, instead
of being written to stderr.