### PR TITLE
Revert writing to /dev/stderr as a file

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -123,9 +123,8 @@ endfunction
 
 function! s:print_stderr(output)
   let lines = split(a:output, '\n')
-  let dest = filter([$VADER_OUTPUT_FILE, '/dev/stderr'], 'filewritable(v:val)')
-  if len(dest)
-    call writefile(lines, dest[0], 'a')
+  if filewritable($VADER_OUTPUT_FILE)
+    call writefile(lines, $VADER_OUTPUT_FILE, 'a')
   else
     let tmp = tempname()
     call writefile(lines, tmp)


### PR DESCRIPTION
It is problematic in both Vim and Neovim.
Ref: https://github.com/junegunn/vader.vim/pull/73#issuecomment-222520976.

You can still use VADER_OUTPUT_FILE=/dev/stderr, but then Vim needs to
be used in silent ex mode (`vim -es`), and Neovim in headless mode
(`nvim --headless`).