### PR TITLE
Improve VaderThrows to set g:vader_exception and g:vader_throwpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ In Execute block, the following commands are provided.
     - `Assert <boolean expr>[, message]`
     - `AssertEqual <expected>, <got>[, message]`
     - `AssertNotEqual <unexpected>, <got>[, message]`
-    - `AssertThrows <expr>`
+    - `AssertThrows <command>`
+        - This will set `g:vader_exception` (from `v:exception`) and
+          `g:vader_throwpoint` (from `v:throwpoint`).
 - Other commands
     - `Log "Message"`
     - `Save <name>[, ...]`

--- a/autoload/vader/assert.vim
+++ b/autoload/vader/assert.vim
@@ -79,6 +79,8 @@ function! vader#assert#throws(exp)
   try
     execute a:exp
   catch
+    let g:vader_exception = v:exception
+    let g:vader_throwpoint = v:throwpoint
     let ok = 1
   endtry
 

--- a/doc/vader.txt
+++ b/doc/vader.txt
@@ -153,7 +153,9 @@ In Execute block, the following commands are provided.
    - Assert <boolean expr>[, message]
    - AssertEqual <expected>, <got>[, message]
    - AssertNotEqual <unexpected>, <got>[, message]
-   - AssertThrows <expr>
+   - AssertThrows <command>
+     This will set `g:vader_exception` (see |v:exception|) and
+     `g:vader_throwpoint` (see |v:throwpoint|).
  - Other commands
    - `Log "Message"`
    - Save <name>[, ...]

--- a/test/feature/suite1.vader
+++ b/test/feature/suite1.vader
@@ -3,7 +3,18 @@ Execute (Assert and AssertEqual command):
   Assert 1 == 1
   AssertEqual 'hey', tolower('HEY')
   AssertEqual 'vader.vader', fnamemodify(g:vader_file, ':t')
+
+Execute (AssertThrows):
+  function! VaderThrows()
+    echoerr 'Error from VaderThrows'
+  endfunction
+  command! VaderThrows call VaderThrows()
   AssertThrows call reverse('not a list')
+  AssertEqual g:vader_exception, 'Vim(call):E686: Argument of reverse() must be a List'
+  AssertEqual g:vader_throwpoint, 'function vader#assert#throws, line 5'
+  AssertThrows VaderThrows
+  AssertEqual g:vader_exception, 'Vim(echoerr):Error from VaderThrows'
+  AssertEqual g:vader_throwpoint, 'function vader#assert#throws[5]..VaderThrows, line 1'
 
 Execute (FIXME: AssertThrows expects an exception to be thrown):
   AssertThrows call reverse([1, 2, 3])

--- a/test/regression/characterwise-macro.vader
+++ b/test/regression/characterwise-macro.vader
@@ -22,4 +22,4 @@ Execute (Assertions):
   AssertEqual getline(1), getline(1)
   AssertNotEqual getline(1), getline(3)
   AssertThrows getline()
-
+  AssertEqual g:vader_exception, "Vim:E492: Not an editor command: getline()"


### PR DESCRIPTION
Fixes https://github.com/junegunn/vader.vim/issues/86.

Not sure if the tests should use the `/^Vim\%((\a\+)\)\=:E123/` pattern (via `:h :catch`)?!