### PR TITLE
plugin/vader.vim: check for &compatible and use g:loaded_vader

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -21,10 +21,6 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if exists("g:loaded_vader")
-  finish
-endif
-let g:loaded_vader = 1
 let s:register = {}
 let s:register_undefined = []
 let s:indent = 2

--- a/plugin/vader.vim
+++ b/plugin/vader.vim
@@ -21,9 +21,10 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if exists(":Vader")
+if exists('g:loaded_vader') || &compatible
   finish
 endif
+let g:loaded_vader = 1
 
 function s:vader(...) range
   if a:lastline - a:firstline > 0 && a:0 > 1


### PR DESCRIPTION
plugin/vader.vim: check for &compatible and use g:loaded_vader

In case `:set compatible` or `-N` was not used, it is better to not load
the plugin in case of generating an error:

> Error detected while processing function <SNR>22_vader[5]..vader#run:
> line   60:
> E10: \ should be followed by /, ? or &

This also moves `g:loaded_vader` to the plugin, which appears to be the more
common idiom.
