### PR TITLE
Do not check spelling in Vader result buffers

### DIFF
--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -47,8 +47,7 @@ function! vader#window#open()
 
   let s:prev_winid = exists('*win_getid') ? win_getid() : 0
   tabnew
-  setlocal buftype=nofile
-  setlocal noswapfile
+  setlocal buftype=nofile noswapfile nospell
   setf vader-result
   silent f \[Vader\]
   let s:console_tab = tabpagenr()


### PR DESCRIPTION
Result buffers are generated, never edited by the user and contain professional jargon. This makes them ill-suited to be checked for spelling. I haven't added any copyright notice or license to the file because I wasn't sure what to put in there. Let me know if you want me to write something, I'll update the PR then.