### PR TITLE
s:read_vader: Include: call s:read_vader recursively

### DIFF
--- a/autoload/vader/parser.vim
+++ b/autoload/vader/parser.vim
@@ -81,9 +81,9 @@ function! s:read_vader(fn, line1, line2)
     let line = remove(remains, 0)
     let m = matchlist(line, '^Include\(\s*(.*)\s*\)\?:\s*\(.\{-}\)\s*$')
     if !empty(m)
-      let file = findfile(m[2], fnamemodify(a:fn, ':h'))
-      if empty(file)
-        echoerr "Cannot find ".m[2]
+      let file = fnamemodify(a:fn, ':h').'/'.m[2]
+      if !filereadable(file)
+        echoerr 'Cannot find '.m[2].' ('.file.')'
       endif
       if reserved > 0
         let depth += 1
@@ -92,9 +92,8 @@ function! s:read_vader(fn, line1, line2)
         endif
         let reserved -= 1
       endif
-      let included = readfile(file)
-      let reserved += len(included)
-      call extend(remains, included, 0)
+      call extend(lines, s:read_vader(file, 1, 0))
+      let lnum += 1
       continue
     end
 

--- a/test/feature/no-indentation.vader
+++ b/test/feature/no-indentation.vader
@@ -15,7 +15,7 @@ Before; Okay to have block labels if the line is not in a valid vader syntax
 After: This is the last line
 
 
-Include (To see if it's okay to interleave Include): include/setup.vader
+Include (To see if it's okay to interleave Include): ../include/setup.vader
 
 Do;
 2j


### PR DESCRIPTION
This will use the actual file name for included lines.

Fixes https://github.com/junegunn/vader.vim/issues/88.

This is factored out of the improvements to come for https://github.com/junegunn/vader.vim/pull/107.

@junegunn 
I am not sure about the meaning of the `reserved` var in here, so please review extra carefully.