### PR TITLE
Check types with AssertEqual/AssertNotEqual

### DIFF
--- a/autoload/vader/assert.vim
+++ b/autoload/vader/assert.vim
@@ -24,6 +24,16 @@
 
 let s:assertions = [0, 0]
 
+let s:type_names = {
+      \ 0: 'Number',
+      \ 1: 'String',
+      \ 2: 'Funcref',
+      \ 3: 'List',
+      \ 4: 'Dictionary',
+      \ 5: 'Float',
+      \ 6: 'Boolean',
+      \ 7: 'Null' }
+
 function! vader#assert#reset()
   let s:assertions = [0, 0]
 endfunction
@@ -50,10 +60,20 @@ function! vader#assert#true(...)
   return 1
 endfunction
 
+function! s:check_types(...)
+  let [exp, got] = a:000[0:1]
+  if type(exp) !=# type(got)
+    throw get(a:000, 2, printf("type mismatch: %s (%s) should be equal to %s (%s)",
+          \ string(got), get(s:type_names, type(got), type(got)),
+          \ string(exp), get(s:type_names, type(exp), type(exp))))
+  endif
+endfunction
+
 function! vader#assert#equal(...)
   let [exp, got] = a:000[0:1]
   let s:assertions[1] += 1
 
+  call s:check_types(exp, got)
   if exp !=# got
     throw get(a:000, 2, printf("%s should be equal to %s", string(got), string(exp)))
   endif
@@ -65,6 +85,7 @@ function! vader#assert#not_equal(...)
   let [exp, got] = a:000[0:1]
   let s:assertions[1] += 1
 
+  call s:check_types(exp, got)
   if exp ==# got
     throw get(a:000, 2, printf("%s should not be equal to %s", string(got), string(exp)))
   endif

--- a/test/feature/save-restore.vader
+++ b/test/feature/save-restore.vader
@@ -35,7 +35,7 @@ Execute (Restore everything):
   let number = &number
   Restore
   AssertEqual 3, g:xyz
-  AssertEqual 4, $ENVVAR
+  AssertEqual '4', $ENVVAR
   AssertEqual !number, &number
 
 Execute (g:undefined should not exist):


### PR DESCRIPTION
This should be done only for incompatible types maybe (i.e. when
comparing list/dict with something else).

This is meant to make the error when comparing a list with something
else more meaningful, where you currently get the following only:

> Vim(if):E691: Can only compare List with List