### PR TITLE
Fix comparison to 0 returning weird results

### DIFF
--- a/autoload/vader/assert.vim
+++ b/autoload/vader/assert.vim
@@ -53,8 +53,13 @@ endfunction
 function! vader#assert#equal(...)
   let [exp, got] = a:000[0:1]
   let s:assertions[1] += 1
+  if exp is 0 || got is 0
+      let l:comparison = exp isnot# got
+  else
+      let l:comparison =  exp !=# got
+  endif
 
-  if exp !=# got
+  if l:comparison
     throw get(a:000, 2, printf("%s should be equal to %s", string(got), string(exp)))
   endif
   let s:assertions[0] += 1
@@ -65,7 +70,13 @@ function! vader#assert#not_equal(...)
   let [exp, got] = a:000[0:1]
   let s:assertions[1] += 1
 
-  if exp ==# got
+  if exp is 0 || got is 0
+      let l:comparison = exp is# got
+  else
+      let l:comparison =  exp ==# got
+  endif
+
+  if l:comparison
     throw get(a:000, 2, printf("%s should not be equal to %s", string(got), string(exp)))
   endif
   let s:assertions[0] += 1

--- a/test/feature/suite2.vader
+++ b/test/feature/suite2.vader
@@ -28,3 +28,10 @@ Expect (Comparison is case-sensitive):
   some string
   MORE string
   even more string
+
+Execute (Comparison to 0 is done correctly):
+  AssertEqual 0, 0
+  AssertThrow vader#assert#equal(0, 'a string')
+  AssertThrow vader#assert#equal('a string', 0)
+  AssertNotEqual 'a string', 0
+  AssertNotEqual 0, 'a string'


### PR DESCRIPTION
Fixes #115, for some reason in vimscript `0 == 'a string'` returns `1`