### PR TITLE
Make s:switch_to_workbench work with nohidden

### DIFF
--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -35,7 +35,7 @@ endfunction
 
 function! s:switch_to_workbench()
   execute 'normal! '.s:workbench_tab.'gt'
-  execute 'b' s:workbench_bfr
+  execute 'b!' s:workbench_bfr
 endfunction
 
 function! vader#window#open()


### PR DESCRIPTION
Do not require tests to use `set hidden`, just to prevent unrelated
errors when Vader cannot switch back to the workbench.

Ref: https://github.com/neomake/neomake/commit/468b27ce51674b7a6651e98a9383f50ac93d4091