### PR TITLE
vader#window#append: handle non-existing s:console_buffered

### DIFF
--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -95,6 +95,10 @@ function! vader#window#append(message, indent, ...)
   if get(a:, 1, 1)
     let message = substitute(message, '\s*$', '', '')
   endif
+  if !exists('s:console_buffered')
+    echom 'Vader:' message
+    return 0
+  endif
   call add(s:console_buffered, message)
   return len(s:console_buffered)
 endfunction


### PR DESCRIPTION
This happens when you are using "Log" in a script/function that gets
executed before Vader is setup.
This patch makes it fall back to using `:echom` instead.

Without this patch, you will get some weird error instead:

> Vim(call):E121: Undefined variable: s:console_buffered