### PR TITLE
test/vimrc: set noswapfile viminfo=

### DIFF
--- a/test/vimrc
+++ b/test/vimrc
@@ -3,3 +3,5 @@ set rtp+=../
 filetype plugin indent on
 syntax enable
 set nomore
+set noswapfile
+set viminfo=


### PR DESCRIPTION
Both are not required for the tests, and can get in the way when running
tests interactively in parallel (since the buffer is opened already, and
a swapfile would exist).

Maybe better?!  (since viminfo can be useful with interactive tests, and we can specify `-i viminfo` in the test runner instead)

```diff
diff --git i/test/vimrc w/test/vimrc
index 529daad..a19ada0 100644
--- i/test/vimrc
+++ w/test/vimrc
@@ -1,5 +1,6 @@
 filetype off
-set rtp+=../
+let &runtimepath .= ','.expand('<sfile>:p:h:h')
 filetype plugin indent on
 syntax enable
 set nomore
+set noswapfile
```