### PR TITLE
Set &l:comments to what vim uses

### DIFF
--- a/ftplugin/vader.vim
+++ b/ftplugin/vader.vim
@@ -35,6 +35,7 @@ let b:vader_eos = '\(.*\n'.vader#syntax#_head().'\)\|\%$'
 setlocal shiftwidth=2 tabstop=2 softtabstop=2 expandtab
 setlocal iskeyword+=#
 let &l:commentstring = '" %s'
+let &l:comments      = 'sO:" -,mO:"  ,eO:"",:"'
 
 nnoremap <buffer><silent> [[ :call search(b:vader_label, 'bW')<CR>
 nnoremap <buffer><silent> [] :call search(b:vader_eos, 'bW')<CR>


### PR DESCRIPTION
The default prevents things like, say, writing multi-line comments and
having wrapping etc work properly.  Here we simply use the same
`comments` setting that the `vim` filetype does.