### PR TITLE
Document VADER_OUTPUT_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Running Vader tests
     - If the description of `Do` or `Execute` block includes `FIXME` or `TODO`,
       the block is recognized as a pending test case and does not affect the
       exit status.
+    - If the environment variable `VADER_OUTPUT_FILE` is set, the test results
+      will be written to it as well
 
 Syntax of .vader file
 ---------------------

--- a/doc/vader.txt
+++ b/doc/vader.txt
@@ -75,6 +75,8 @@ RUNNING VADER TESTS                                  *vader-running-vader-tests*
    - If the description of `Do` or `Execute` block includes `FIXME` or `TODO`,
      the block is recognized as a pending test case and does not affect the
      exit status.
+   - If the environment variable `VADER_OUTPUT_FILE` is set, the test results
+     will be written to it as well
 
 
                                                                        *vader-3*


### PR DESCRIPTION
This PR adds documentation for the `VADER_OUTPUT_FILE` environment variable, which is particularly useful when running Neovim in CI (since it doesn't log to stdout like Vim).