### PR TITLE
Use fnameescape() with `:file`

### DIFF
--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -49,7 +49,7 @@ function! vader#window#open()
   tabnew
   setlocal buftype=nofile noswapfile nospell
   setf vader-result
-  silent f \[Vader\]
+  silent exe 'file '.fnameescape('[Vader]')
   let s:console_tab = tabpagenr()
   let s:console_bfr = bufnr('')
   let s:console_buffered = []
@@ -59,7 +59,7 @@ function! vader#window#open()
   tabnew
   setlocal buftype=nofile
   setlocal noswapfile
-  silent f \[Vader-workbench\]
+  silent exe 'file '.fnameescape('[Vader-workbench]')
   let s:workbench_tab = tabpagenr()
   let s:workbench_bfr = bufnr('')
 endfunction


### PR DESCRIPTION
This is required to handle `[]` in `&isfname`, which is the case on
Windows.
Without this patch '\[' was used literally in the buffer name.