### PR TITLE
Set g:vader_case_ok before After blocks

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -322,6 +322,7 @@ function! s:run(filename, cases, options)
 
     if !empty(after)
       let s:indent = 2
+      let g:vader_case_ok = ok
       let ok = s:execute(prefix, 'after', after, '') && ok
     endif
 

--- a/test/feature/before-after.vader
+++ b/test/feature/before-after.vader
@@ -9,6 +9,8 @@ After:
   Log 'After block increases counter by 2'
   let g:counter += 2
 
+  AssertEqual g:vader_case_ok, 1
+
 Execute:
   Log 'It should be 1'
   AssertEqual 1, g:counter
@@ -24,4 +26,14 @@ After:
 Execute:
   AssertEqual 6, g:counter
   unlet g:counter
-  Log 'Goodbye!'
+
+
+# Test g:vader_case_ok with test failure.
+After (g:vader_case_ok should be 0):
+  AssertEqual g:vader_case_ok, 0
+
+Execute (TODO: expected failure):
+  Assert 0
+
+# Remove After hook
+After:


### PR DESCRIPTION
`After` blocks get called always, but it is useful for them to know if
the test succeeded so far.

I.e. with Neomake I am checking if windows have been closed when tearing
down the tests, but this should be skipped if the test itself did not
finish because of a previous failure (and therefore windows are likely
not closed).