### PR TITLE
Output console messages directly with :Vader! - improve Neovim support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   include:
     - env: TESTVIM=vim
     - env: TESTVIM=nvim
+    - env: TESTVIM=nvim VADER_OUTPUT_FILE=/dev/stderr
 
 install:
   - pip install --user covimerage
@@ -25,7 +26,6 @@ install:
       TRAVIS_BUILD_DIR=/tmp eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
       gem install neovim
       pip install --user neovim
-      export VADER_OUTPUT_FILE=/dev/stderr
     fi
     popd
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Running Vader tests
       the block is recognized as a pending test case and does not affect the
       exit status.
     - If the environment variable `VADER_OUTPUT_FILE` is set, the test results
-      will be written to it as well
+      will be written to it as well, otherwise they are written to stderr using
+      different methods (depending on Neovim/Vim).
 
 Syntax of .vader file
 ---------------------

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -119,10 +119,10 @@ function! vader#run(bang, ...) range
         redir => ver
         silent version
         redir END
-        call s:print_stderr(ver . "\n\n")
+        call vader#print_stderr(ver . "\n\n")
       endif
 
-      call s:print_stderr(g:vader_report)
+      call vader#print_stderr(g:vader_report)
       if successful
         qall!
       else
@@ -134,7 +134,7 @@ function! vader#run(bang, ...) range
   catch
     let error = 'Vader error: '.v:exception.' (in '.v:throwpoint.')'
     if a:bang
-      call s:print_stderr(error)
+      call vader#print_stderr(error)
       cq
     else
       echoerr error
@@ -144,7 +144,7 @@ function! vader#run(bang, ...) range
   endtry
 endfunction
 
-function! s:print_stderr(output)
+function! vader#print_stderr(output) abort
   let lines = split(a:output, '\n')
   if !empty($VADER_OUTPUT_FILE)
     call writefile(lines, $VADER_OUTPUT_FILE, 'a')

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -147,40 +147,54 @@ function! vader#run(bang, ...) range
   endtry
 endfunction
 
-let s:stderr_buffer = []
-
-function! vader#print_stderr(output) abort
-  let lines = split(a:output, '\n')
-  if !empty($VADER_OUTPUT_FILE)
+" Define vader#print_stderr based on available features / used options.
+" This is done a) for performance reasons, but b) mainly because `mode()`
+" might be e.g. "ic" during tests, and we need to detect the initial usage of
+" "-es" / "-Es".
+if !empty($VADER_OUTPUT_FILE)
+  function! vader#print_stderr(output) abort
+    let lines = split(a:output, '\n')
     call writefile(lines, $VADER_OUTPUT_FILE, 'a')
-  elseif has('nvim')
-    if exists('v:stderr')
+  endfunction
+elseif has('nvim')
+  if exists('v:stderr')
+    function! vader#print_stderr(output) abort
       call chansend(v:stderr, a:output)
-    else
+    endfunction
+  else
+    function! vader#print_stderr(output) abort
+      let lines = split(a:output, '\n')
       call writefile(lines, '/dev/stderr', 'a')
-    endif
-  elseif mode(1) ==# 'ce' || mode(1) ==# 'cv'  " -es (silent ex mode)
+    endfunction
+  endif
+elseif mode(1) ==# 'ce' || mode(1) ==# 'cv'  " -es (silent ex mode)
+  function! vader#print_stderr(output) abort
+    let lines = split(a:output, '\n')
     for line in lines
       verbose echon line."\n"
     endfor
-  else
-    " Cannot output single lines reliably in this case.
-    if empty(s:stderr_buffer)
-      let msg = printf('Vader note: cannot print to stderr reliably/directly.  Please consider using %s''s -es/-Es option.', has('nvim') ? 'Neovim' : 'Vim')
-      call add(s:stderr_buffer, msg)
-      augroup vader_exit
-        autocmd VimLeave * call s:output_stderr_buffer()
-      augroup END
-    endif
-    call extend(s:stderr_buffer, lines)
-  endif
-endfunction
+  endfunction
+else
+  " Cannot output single lines reliably in this case.
+  let s:stderr_buffer = [
+        \ printf('Vader note: cannot print to stderr reliably/directly.  Please consider using %s''s -es/-Es option (mode=%s).',
+            \ has('nvim') ? 'Neovim' : 'Vim',
+            \ mode(1))]
+  function! s:output_stderr_buffer() abort
+    let s:tmpfile = tempname()
+    call writefile(s:stderr_buffer, s:tmpfile)
+    execute printf('silent !%s %s 1>&2', s:cat, s:tmpfile)
+    let s:stderr_buffer = []
+  endfunction
+  augroup vader_exit
+    autocmd VimLeave * call s:output_stderr_buffer()
+  augroup END
 
-function! s:output_stderr_buffer() abort
-  let s:tmpfile = tempname()
-  call writefile(s:stderr_buffer, s:tmpfile)
-  execute printf('silent !%s %s 1>&2', s:cat, s:tmpfile)
-endfunction
+  function! vader#print_stderr(output) abort
+    let lines = split(a:output, '\n')
+    call extend(s:stderr_buffer, lines)
+  endfunction
+endif
 
 function! s:split_args(arg)
   let varnames = split(a:arg, ',')

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -49,6 +49,13 @@ function! vader#run(bang, ...) range
     let patterns = [expand('%')]
   endif
 
+  if a:bang && !options.quiet
+    redir => ver
+    silent version
+    redir END
+    call vader#print_stderr(ver . "\n\n")
+  endif
+
   call vader#assert#reset()
   call s:prepare()
   try
@@ -115,13 +122,6 @@ function! vader#run(bang, ...) range
     call setqflist(qfl)
 
     if a:bang
-      if !options.quiet
-        redir => ver
-        silent version
-        redir END
-        call vader#print_stderr(ver . "\n\n")
-      endif
-
       call vader#print_stderr(g:vader_report)
       if successful
         qall!

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -149,10 +149,11 @@ function! vader#print_stderr(output) abort
   if !empty($VADER_OUTPUT_FILE)
     call writefile(lines, $VADER_OUTPUT_FILE, 'a')
   else
-    let tmp = tempname()
-    call writefile(lines, tmp)
-    execute printf('silent !%s %s 1>&2', s:cat, tmp)
-    call delete(tmp)
+    if !exists('s:tmpfile')
+      let s:tmpfile = tempname()
+    endif
+    call writefile(lines, s:tmpfile)
+    execute printf('silent !%s %s 1>&2', s:cat, s:tmpfile)
   endif
 endfunction
 

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -157,6 +157,32 @@ function! vader#print_stderr(output) abort
   endif
 endfunction
 
+" Overwrite vader#print_stderr with specialized version for Neovim.
+" v:stderr is available since Neovim v0.3.0.
+if has('nvim')
+  if !empty($VADER_ECHO_MESSAGES)
+    if $VADER_ECHO_MESSAGES ==# 'stdout'
+      let s:nvim_channel = stdioopen({})
+      function! vader#print_stderr(output) abort
+        call chansend(s:nvim_channel, a:output)
+      endfunction
+    else
+      function! vader#print_stderr(output) abort
+        call chansend(v:stderr, a:output)
+      endfunction
+    endif
+  elseif exists('v:stderr')
+    function! vader#print_stderr(output) abort
+      call chansend(v:stderr, a:output)
+    endfunction
+  elseif exists('*nvim_list_uis') && !empty(nvim_list_uis())
+    " --headless is used (detected with Neovim v0.3.0+)
+    function! vader#print_stderr(output) abort
+      echon a:output
+    endfunction
+  endif
+endif
+
 function! s:split_args(arg)
   let varnames = split(a:arg, ',')
   let names = []

--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -98,7 +98,7 @@ function! vader#window#append(message, indent, ...)
   if get(a:, 1, 1)
     let message = substitute(message, '\s*$', '', '')
   endif
-  if !empty($VADER_ECHO_MESSAGES)
+  if get(g:, 'vader_bang', 0)
     call vader#print_stderr(message."\n")
     return 0
   elseif !exists('s:console_buffered')

--- a/autoload/vader/window.vim
+++ b/autoload/vader/window.vim
@@ -98,7 +98,10 @@ function! vader#window#append(message, indent, ...)
   if get(a:, 1, 1)
     let message = substitute(message, '\s*$', '', '')
   endif
-  if !exists('s:console_buffered')
+  if !empty($VADER_ECHO_MESSAGES)
+    call vader#print_stderr(message."\n")
+    return 0
+  elseif !exists('s:console_buffered')
     echom 'Vader:' message
     return 0
   endif


### PR DESCRIPTION
This skips the console buffer for `:Vader!`, but echos messages directly to stderr.

Writing to stderr is improved for Neovim (v0.3.0+), which should make this work on Windows by default.

My main motivation here was to make this work on Windows with Neovim, but then also noticed that it is really good to have the output as it comes already.

TODO:

- [ ] doc

Includes https://github.com/junegunn/vader.vim/pull/177.