### PR TITLE
Travis: cover :Vader use case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ script:
   - VADER_TEST_VIM="covimerage run --source $PWD --data-file $PWD/.coverage_covimerage --no-report $TESTVIM" ./test/run-tests.sh
   # Test/cover :Vader use case (without bang).
   - |
-    covimerage run --append --source . --no-report $TESTVIM -Nu test/vimrc -c 'Vader test/*' -c 'exe g:vader_result.successful ? "qall!" : "cq"'
+    covimerage run --append --source . --no-report $TESTVIM -Nu test/vimrc \
+      -c 'Vader test/*' \
+      -c 'exe get(get(g:, "vader_result", {}), "successful", 0) ? "qall!" : "cq"'
 
 after_success:
   - covimerage -vv xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ script:
   # Wrap $TESTVIM with covimerage for coverage reporting.
   # Uses --no-report, because test/run-tests.sh changes the directory, and that does not pick up .coveragerc then.
   - VADER_TEST_VIM="covimerage run --source $PWD --data-file $PWD/.coverage_covimerage --no-report $TESTVIM" ./test/run-tests.sh
+  # Test/cover :Vader use case (without bang).
+  - |
+    covimerage run --append --source . --no-report $TESTVIM -Nu test/vimrc -c 'Vader test/*' -c 'exe g:vader_result.successful ? "qall!" : "cq"'
 
 after_success:
   - covimerage -vv xml

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -94,7 +94,6 @@ function! vader#run(bang, ...) range
       endif
     endfor
 
-    let stats = vader#assert#stat()
     let successful = success + pending == total
     let g:vader_result = {
           \ 'total': total,
@@ -102,6 +101,8 @@ function! vader#run(bang, ...) range
           \ 'pending': pending,
           \ 'successful': successful,
           \ }
+
+    let stats = vader#assert#stat()
     call vader#window#append(printf('Success/Total: %s/%s (%sassertions: %d/%d)',
           \ success, total, (pending > 0 ? pending . ' pending, ' : ''),
           \ stats[0], stats[1]), 0)

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -95,6 +95,13 @@ function! vader#run(bang, ...) range
     endfor
 
     let stats = vader#assert#stat()
+    let successful = success + pending == total
+    let g:vader_result = {
+          \ 'total': total,
+          \ 'success': success,
+          \ 'pending': pending,
+          \ 'successful': successful,
+          \ }
     call vader#window#append(printf('Success/Total: %s/%s (%sassertions: %d/%d)',
           \ success, total, (pending > 0 ? pending . ' pending, ' : ''),
           \ stats[0], stats[1]), 0)
@@ -115,7 +122,7 @@ function! vader#run(bang, ...) range
       endif
 
       call s:print_stderr(g:vader_report)
-      if success + pending == total
+      if successful
         qall!
       else
         cq


### PR DESCRIPTION
This adds g:vader_result, where "successful" is used from to exit
manually.