### PR TITLE
Prints a failure message if Vader not enabled

### DIFF
--- a/plugin/vader.vim
+++ b/plugin/vader.vim
@@ -21,9 +21,23 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-if exists('g:loaded_vader') || &compatible
+if exists('g:loaded_vader')
   finish
 endif
+
+function! s:vader_compat(...) range
+  echomsg 'Cannot run Vader as compatible mode set'
+endfunction
+
+if &compatible
+  if !exists('g:loaded_compat')
+    command! -bang -nargs=* -range -complete=file Vader <line1>,<line2>call s:vader_compat(<bang>0, <f-args>)
+    let g:loaded_compat = 1
+  endif
+
+  finish
+endif
+
 let g:loaded_vader = 1
 
 function! s:vader(...) range

--- a/plugin/vader.vim
+++ b/plugin/vader.vim
@@ -40,12 +40,18 @@ endif
 
 let g:loaded_vader = 1
 
-function! s:vader(...) range
-  if a:lastline - a:firstline > 0 && a:0 > 1
-    echoerr 'Range and file arguments are mutually exclusive'
-    return
-  endif
-  execute printf("%d,%dcall vader#run(%s)", a:firstline, a:lastline, string(a:000)[1:-2])
-endfunction
+if &compatible
+  function! s:vader(...) range
+    echoerr 'Cannot run Vader in compatible mode'
+  endfunction
+else
+  function! s:vader(...) range
+    if a:lastline - a:firstline > 0 && a:0 > 1
+      echoerr 'Range and file arguments are mutually exclusive'
+      return
+    endif
+    execute printf("%d,%dcall vader#run(%s)", a:firstline, a:lastline, string(a:000)[1:-2])
+  endfunction
+endif
 
 command! -bang -nargs=* -range -complete=file Vader <line1>,<line2>call s:vader(<bang>0, <f-args>)

--- a/plugin/vader.vim
+++ b/plugin/vader.vim
@@ -25,26 +25,13 @@ if exists('g:loaded_vader')
   finish
 endif
 
-function! s:vader_compat(...) range
-  echomsg 'Cannot run Vader as compatible mode set'
-endfunction
-
-if &compatible
-  if !exists('g:loaded_compat')
-    command! -bang -nargs=* -range -complete=file Vader <line1>,<line2>call s:vader_compat(<bang>0, <f-args>)
-    let g:loaded_compat = 1
-  endif
-
-  finish
-endif
-
-let g:loaded_vader = 1
-
 if &compatible
   function! s:vader(...) range
     echoerr 'Cannot run Vader in compatible mode'
   endfunction
 else
+  let g:loaded_vader = 1
+
   function! s:vader(...) range
     if a:lastline - a:firstline > 0 && a:0 > 1
       echoerr 'Range and file arguments are mutually exclusive'


### PR DESCRIPTION
If Vader is not setup, due to not setting 'nocompatible', vim will emit a message to that effect rather than 'Vader not found' which might lead to confusion.

resolves #179