### PR TITLE
Emits an error if vader not setup.

### DIFF
--- a/plugin/vader.vim
+++ b/plugin/vader.vim
@@ -22,6 +22,9 @@
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 if exists('g:loaded_vader') || &compatible
+  if &compatible
+    echoerr 'Not loading vader as compatible mode set'
+  endif
   finish
 endif
 let g:loaded_vader = 1


### PR DESCRIPTION
Currently, if nocompatible is not set, the Vader command does not exist.
This makes it look as if the install failed.

The patch adds an error message to make it clear that is what happened.

resolves #179