### PR TITLE
Vim: flush stderr output buffer explicitly

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -120,6 +120,9 @@ function! vader#run(bang, ...) range
     call vader#window#cleanup()
 
     if a:bang
+      if exists('*s:output_stderr_buffer')
+        call s:output_stderr_buffer()
+      endif
       if successful
         qall!
       else


### PR DESCRIPTION
Doing so in VimLeave will mess with the alternate screen / when stdout
is not redirected.