### PR TITLE
Fix test for newer Vim

### DIFF
--- a/test/feature/suite1.vader
+++ b/test/feature/suite1.vader
@@ -9,9 +9,14 @@ Execute (AssertThrows):
     echoerr 'Error from VaderThrows'
   endfunction
   command! VaderThrows call VaderThrows()
+
   AssertThrows call reverse('not a list')
-  AssertEqual g:vader_exception, 'Vim(call):E686: Argument of reverse() must be a List'
+  " Might be either:
+  " - Vim(call):E899: Argument of reverse() must be a List or Blob
+  " - Vim(call):E686: Argument of reverse() must be a List
+  Assert g:vader_exception =~# '\V\^Vim(call):E\.\*reverse()', 'Unexpected exception: '.g:vader_exception
   AssertEqual g:vader_throwpoint, 'function vader#assert#throws, line 5'
+
   AssertThrows VaderThrows
   AssertEqual g:vader_exception, 'Vim(echoerr):Error from VaderThrows'
   AssertEqual g:vader_throwpoint, 'function vader#assert#throws[5]..VaderThrows, line 1'


### PR DESCRIPTION
The exception is the following there:

> Vim(call):E899: Argument of reverse() must be a List or Blob