### PR TITLE
Implement SkipIf command to skip tests if a condition is met

### DIFF
--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -352,7 +352,7 @@ function! s:run(filename, cases, options)
       if result != 0
           let pending += 1
           let description = 'reason for skipping: ' . case.comment.skipif
-          call add(qfl, { 'type': 'S', 'filename': a:filename, 'lnum': case.lnum, 'text': description })
+          call s:append(prefix, 'skipped', case.comment.skipif)
           continue
       endif
     endif

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -352,7 +352,7 @@ function! s:run(filename, cases, options)
       if result != 0
           let pending += 1
           let description = 'reason for skipping: ' . case.comment.skipif
-          call s:append(prefix, 'skipped', case.comment.skipif)
+          call s:append(prefix, 'skipif', case.comment.skipif)
           continue
       endif
     endif

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -335,18 +335,18 @@ function! s:run(filename, cases, options)
     " Check for SkipIf command before anything else
     if has_key(case, 'skipif')
       if empty(case.skipif) || join(case.skipif, '') =~# '^\s*$'
-        throw 'SkipIf condition is missing'
+        throw 'SkipIf condition is missing ' . prefix
       elseif len(case.skipif) > 1
         " Require that only a single line is used to avoid 'E488: Trailing
         " characters' warning in eval()
-        throw 'SkipIf must use only a single expression'
+        throw 'SkipIf condition must be a single expression ' . prefix
       endif
 
       let result = eval(case.skipif[0])
 
       " Result of evaluated condition must be a number
       if type(result) != type(0)
-        throw 'Result of SkipIf condition must be a number'
+        throw 'Result of SkipIf condition must be a number ' . prefix
       endif
 
       if result != 0

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -335,18 +335,18 @@ function! s:run(filename, cases, options)
     " Check for SkipIf command before anything else
     if has_key(case, 'skipif')
       if empty(case.skipif) || join(case.skipif, '') =~# '^\s*$'
-        throw 'SkipIf condition is missing ' . prefix
+        throw printf('SkipIf condition is missing at line %d %s', case.lnum, prefix)
       elseif len(case.skipif) > 1
         " Require that only a single line is used to avoid 'E488: Trailing
         " characters' warning in eval()
-        throw 'SkipIf condition must be a single expression ' . prefix
+        throw printf('SkipIf condition must be a single expression at line %d %s', case.lnum, prefix)
       endif
 
       let result = eval(case.skipif[0])
 
       " Result of evaluated condition must be a number
       if type(result) != type(0)
-        throw 'Result of SkipIf condition must be a number ' . prefix
+        throw printf('Result of SkipIf condition must be a number at line %d %s', case.lnum, prefix)
       endif
 
       if result != 0

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -334,12 +334,12 @@ function! s:run(filename, cases, options)
 
     " Check for SkipIf command before anything else
     if has_key(case, 'skipif')
-      if empty(case.skipif) || join(case.skipif, '') =~# '^\s*$'
-        throw printf('SkipIf condition is missing at line %d %s', case.lnum, prefix)
-      elseif len(case.skipif) > 1
+      if len(case.skipif) > 1
         " Require that only a single line is used to avoid 'E488: Trailing
         " characters' warning in eval()
         throw printf('SkipIf condition must be a single expression at line %d %s', case.lnum, prefix)
+      elseif empty(case.skipif) || case.skipif[0] =~# '^\s*$'
+        throw printf('SkipIf condition is missing at line %d %s', case.lnum, prefix)
       endif
 
       let result = eval(case.skipif[0])

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -342,7 +342,7 @@ function! s:run(filename, cases, options)
         throw 'SkipIf must use only a single expression'
       endif
 
-      if eval(case.skipif[0]) == 1
+      if eval(case.skipif[0]) != 0
           let pending += 1
           let description = 'reason for skipping: ' . case.comment.skipif
           call add(qfl, { 'type': 'S', 'filename': a:filename, 'lnum': case.lnum, 'text': description })

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -327,7 +327,30 @@ function! s:run(filename, cases, options)
 
   call vader#window#append("Starting Vader: ". a:filename, 1)
 
+  " Check for SkipIf commands before anything else
   for case in a:cases
+    let cnt += 1
+    let prefix = printf('(%'.just.'d/%'.just.'d)', cnt, total)
+    if has_key(case, 'skipif')
+      if empty(case.skipif)
+          throw 'SkipIf condition is missing'
+      endif
+
+      if eval(join(case.skipif, ' | ')) == 1
+          let pending += 1
+          let description = 'reason for skipping: ' . case.comment.skipif
+          call add(qfl, { 'type': 'S', 'filename': a:filename, 'lnum': case.lnum, 'text': description })
+      endif
+    endif
+  endfor
+
+  let cnt = 0
+
+  for case in a:cases
+    if has_key(case, 'skipif')
+      continue
+    endif
+
     let cnt += 1
     let ok = 1
     let prefix = printf('(%'.just.'d/%'.just.'d)', cnt, total)

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -351,7 +351,6 @@ function! s:run(filename, cases, options)
 
       if result != 0
           let pending += 1
-          let description = 'reason for skipping: ' . case.comment.skipif
           call s:append(prefix, 'skipif', case.comment.skipif)
           continue
       endif

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -332,6 +332,11 @@ function! s:run(filename, cases, options)
     let ok = 1
     let prefix = printf('(%'.just.'d/%'.just.'d)', cnt, total)
 
+    if has_key(case, 'given')
+        let given = case['given']
+        let comment['given'] = get(case.comment, 'given', '')
+    endif
+
     " Check for SkipIf command before anything else
     if has_key(case, 'skipif')
       if len(case.skipif) > 1
@@ -356,7 +361,7 @@ function! s:run(filename, cases, options)
       endif
     endif
 
-    for label in ['given', 'before', 'after', 'then']
+    for label in ['before', 'after', 'then']
       if has_key(case, label)
         execute 'let '.label.' = case[label]'
         let comment[label] = get(case.comment, label, '')

--- a/autoload/vader.vim
+++ b/autoload/vader.vim
@@ -342,7 +342,14 @@ function! s:run(filename, cases, options)
         throw 'SkipIf must use only a single expression'
       endif
 
-      if eval(case.skipif[0]) != 0
+      let result = eval(case.skipif[0])
+
+      " Result of evaluated condition must be a number
+      if type(result) != type(0)
+        throw 'Result of SkipIf condition must be a number'
+      endif
+
+      if result != 0
           let pending += 1
           let description = 'reason for skipping: ' . case.comment.skipif
           call add(qfl, { 'type': 'S', 'filename': a:filename, 'lnum': case.lnum, 'text': description })

--- a/autoload/vader/parser.vim
+++ b/autoload/vader/parser.vim
@@ -129,7 +129,7 @@ function! s:parse_vader(lines, line1)
     endif
 
     let matched = 0
-    for l in ['Before', 'After', 'Given', 'Execute', 'Expect', 'Do', 'Then']
+    for l in ['Before', 'After', 'Given', 'Execute', 'Expect', 'Do', 'Then', 'SkipIf']
       let m = matchlist(line, '^'.l.'\%(\s\+\([^:;(]\+\)\)\?\s*\%((\(.*\))\)\?\s*\([:;]\)\s*$')
       if !empty(m)
         let newlabel = tolower(l)

--- a/syntax/vader.vim
+++ b/syntax/vader.vim
@@ -40,6 +40,7 @@ syn match vaderMessage /(\@<=.*)\@=/ contained contains=Todo
 syn match vaderGivenType /\(Given\s*\)\@<=[^;:()\s]\+/ contained
 syn match vaderExpectType /\(Expect\s*\)\@<=[^;:()\s]\+/ contained
 syn match vaderExecuteType /\(Execute\s*\)\@<=[^;:()\s]\+/ contained
+syn match vaderRequireType /\(Require\s*\)/ contained
 syn match vaderSkipIfType /\(SkipIf\s*\)/ contained
 
 syn match vaderComment /^["#].*/ contains=Todo
@@ -55,6 +56,7 @@ syn region vaderExpect  start=/^Expect\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-
 syn region vaderDo      start=/^Do\(\s*(.*)\)\?\s*:\s*$/      end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderThen    start=/^Then\(\s*(.*)\)\?\s*:\s*$/    end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderExecute start=/^Execute\(\s*(.*)\)\?\s*:\s*$/ end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
+syn region vaderRequire start=/^Require\(\s*(.*)\)\?\s*:\s*$/ end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderSkipIf  start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderBefore  start=/^Before\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderAfter   start=/^After\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
@@ -64,7 +66,6 @@ execute printf('syn region vaderExpectRaw  start=/^Expect\(\s*(.*)\)\?\s*;\s*$/ 
 execute printf('syn region vaderDoRaw      start=/^Do\(\s*(.*)\)\?\s*;\s*$/      end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderThenRaw    start=/^Then\(\s*(.*)\)\?\s*;\s*$/    end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderExecuteRaw start=/^Execute\(\s*(.*)\)\?\s*;\s*$/ end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
-execute printf('syn region vaderSkipIfRaw  start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/  end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderBeforeRaw  start=/^Before\(\s*(.*)\)\?\s*;\s*$/  end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderAfterRaw   start=/^After\(\s*(.*)\)\?\s*;\s*$/   end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 
@@ -87,6 +88,7 @@ hi def link vaderThenRaw     Conditional
 hi def link vaderExecute     Statement
 hi def link vaderExecuteRaw  Statement
 hi def link vaderExecuteType Identifier
+hi def link vaderRequire     Todo
 hi def link vaderSkipIf      Exception
 hi def link vaderSkipIfType  Exception
 hi def link vaderSkipIfRaw   Exception

--- a/syntax/vader.vim
+++ b/syntax/vader.vim
@@ -55,7 +55,7 @@ syn region vaderExpect  start=/^Expect\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-
 syn region vaderDo      start=/^Do\(\s*(.*)\)\?\s*:\s*$/      end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderThen    start=/^Then\(\s*(.*)\)\?\s*:\s*$/    end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderExecute start=/^Execute\(\s*(.*)\)\?\s*:\s*$/ end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
-syn region vaderSkipIf start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
+syn region vaderSkipIf  start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderBefore  start=/^Before\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderAfter   start=/^After\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 
@@ -64,6 +64,7 @@ execute printf('syn region vaderExpectRaw  start=/^Expect\(\s*(.*)\)\?\s*;\s*$/ 
 execute printf('syn region vaderDoRaw      start=/^Do\(\s*(.*)\)\?\s*;\s*$/      end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderThenRaw    start=/^Then\(\s*(.*)\)\?\s*;\s*$/    end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderExecuteRaw start=/^Execute\(\s*(.*)\)\?\s*;\s*$/ end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
+execute printf('syn region vaderSkipIfRaw  start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/  end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderBeforeRaw  start=/^Before\(\s*(.*)\)\?\s*;\s*$/  end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 execute printf('syn region vaderAfterRaw   start=/^After\(\s*(.*)\)\?\s*;\s*$/   end=/%s/ contains=vaderMessage,vaderCommandRaw,@vaderIgnored nextgroup=@vaderTopLevel skipempty', vader#syntax#_head())
 
@@ -88,6 +89,7 @@ hi def link vaderExecuteRaw  Statement
 hi def link vaderExecuteType Identifier
 hi def link vaderSkipIf      Exception
 hi def link vaderSkipIfType  Exception
+hi def link vaderSkipIfRaw   Exception
 hi def link vaderExpect      Boolean
 hi def link vaderExpectRaw   Boolean
 hi def link vaderMessage     Title

--- a/syntax/vader.vim
+++ b/syntax/vader.vim
@@ -40,6 +40,7 @@ syn match vaderMessage /(\@<=.*)\@=/ contained contains=Todo
 syn match vaderGivenType /\(Given\s*\)\@<=[^;:()\s]\+/ contained
 syn match vaderExpectType /\(Expect\s*\)\@<=[^;:()\s]\+/ contained
 syn match vaderExecuteType /\(Execute\s*\)\@<=[^;:()\s]\+/ contained
+syn match vaderSkipIfType /\(SkipIf\s*\)/ contained
 
 syn match vaderComment /^["#].*/ contains=Todo
 syn match vaderSepCaret /^^.*/ contains=Todo
@@ -54,6 +55,7 @@ syn region vaderExpect  start=/^Expect\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-
 syn region vaderDo      start=/^Do\(\s*(.*)\)\?\s*:\s*$/      end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderThen    start=/^Then\(\s*(.*)\)\?\s*:\s*$/    end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderExecute start=/^Execute\(\s*(.*)\)\?\s*:\s*$/ end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
+syn region vaderSkipIf start=/^SkipIf\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderBefore  start=/^Before\(\s*(.*)\)\?\s*:\s*$/  end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 syn region vaderAfter   start=/^After\(\s*(.*)\)\?\s*:\s*$/   end=/\(^[^ "^#~=*-]\)\@=/ contains=vaderMessage,vaderCommand,vaderComment,@vaderIgnored nextgroup=@vaderTopLevel skipempty
 
@@ -84,6 +86,8 @@ hi def link vaderThenRaw     Conditional
 hi def link vaderExecute     Statement
 hi def link vaderExecuteRaw  Statement
 hi def link vaderExecuteType Identifier
+hi def link vaderSkipIf      Exception
+hi def link vaderSkipIfType  Exception
 hi def link vaderExpect      Boolean
 hi def link vaderExpectRaw   Boolean
 hi def link vaderMessage     Title

--- a/test/feature/require.vader
+++ b/test/feature/require.vader
@@ -1,0 +1,14 @@
+Require (require something to run test):
+  if 1
+    VaderSkip
+  endif
+
+Given:
+  This is just a test
+
+Do (nothing):
+  jk
+
+Expect:
+  This is not the same as Given so will fail
+  if the entire test file is not skipped

--- a/test/feature/skipif.vader
+++ b/test/feature/skipif.vader
@@ -1,0 +1,17 @@
+Given:
+  hello
+
+SkipIf (skip this test for some reason):
+  1
+
+Do:
+  gUw
+
+Expect:
+  HELLO
+
+Do:
+  g~~
+
+Expect:
+  HELLO

--- a/test/feature/skipif.vader
+++ b/test/feature/skipif.vader
@@ -2,16 +2,12 @@ Given:
   hello
 
 SkipIf (skip this test for some reason):
-  1
+  if 1
+    VaderSkip
+  endif
 
-Do:
-  gUw
+Do (nothing):
+  jk
 
-Expect:
-  HELLO
-
-Do:
-  g~~
-
-Expect:
+Expect (this would fail but the test is skipped):
   HELLO


### PR DESCRIPTION
As per #178, this PR implements a `SkipIf` command to skip a test if a condition is met. I have purposefully left out changes to vader's documentation and tests until the implementation has been discussed.

The command has been tested with one of my own plugins under neovim v0.3.8 and vim v8.0 on Mac OSX 10.14.6. Internally, if a test is skipped, we continue with the next case instead of throwing an exception since continuing seemed to fit better with the existing code. This is my first PR for vader.vim so bear with me if the implementation is not spot on.

The command is used as follows. 

```
SkipIf [(reason for skipping)]:
  [oneline vimscript]
```

Currently, a single line for the condition (e.g. a function call) must be used in order to avoid a `E488: Trailing characters` error when calling `eval` on the condition. The output produced is as follows. Notice that pending is 1 since a single test is skipped.

```
Starting Vader: 1 suite(s), 4 case(s)
  Starting Vader: mytest.vader
    (1/4) [  GIVEN]
    (1/4) [EXECUTE]
    (1/4) [ EXPECT]
    (2/4) [  GIVEN]
    (2/4) [EXECUTE]
    (2/4) [ EXPECT]
    (3/4) [  GIVEN]
    (3/4) [EXECUTE]
    (3/4) [ EXPECT]
    (4/4) [ SKIPIF] reason for skipping
  Success/Total: 3/4 (1 pending)
Success/Total: 3/4 (1 pending, assertions: 0/0)
Elapsed time: 0.179752 sec.
```

Screenshots with the [seoul256.vim](https://github.com/junegunn/seoul256.vim) colorscheme:

<img width="252" alt="Screenshot 2019-10-07 at 14 13 09" src="https://user-images.githubusercontent.com/1846147/67007443-b073c700-f0e7-11e9-9cb6-3bdd24eb9cdb.png">
<img width="468" alt="Screenshot 2019-10-17 at 14 10 46" src="https://user-images.githubusercontent.com/1846147/67007587-06486f00-f0e8-11e9-9c45-83f9b8a9adb4.png">

Things left to do:
- [ ] Add log message for skip
- [ ] Add documentation
- [ ] Add vader tests
- [ ] Resolve any security concerns from use of `eval`