### PR TITLE
Add newline (+indent) before "should be equal to"

### DIFF
--- a/autoload/vader/assert.vim
+++ b/autoload/vader/assert.vim
@@ -79,7 +79,7 @@ function! vader#assert#equal(...)
     let type_name = get(s:type_names, type)
     let type_name_plural = type_name ==# 'Dictionary' ? 'Dictionaries' : type_name.'s'
     let msg = (type == type({}) || type == type([]))
-          \ ? printf("Unequal %s\n      %%s should be equal to\n      %%s", type_name_plural)
+          \ ? printf("Unequal %s\n      %%s\n      should be equal to\n      %%s", type_name_plural)
           \ : '%s should be equal to %s'
     throw get(a:000, 2, printf(msg, string(Got), string(Exp)))
   endif

--- a/test/feature/units.vader
+++ b/test/feature/units.vader
@@ -1,6 +1,6 @@
 Execute (vader#assert#equal checks types):
   AssertThrows call vader#assert#equal({}, {1: 'a'})
-  AssertEqual g:vader_exception, "Unequal Dictionaries\n      {'1': 'a'} should be equal to\n      {}"
+  AssertEqual g:vader_exception, "Unequal Dictionaries\n      {'1': 'a'}\n      should be equal to\n      {}"
 
   AssertThrows call vader#assert#equal([], [1])
-  AssertEqual g:vader_exception, "Unequal Lists\n      [1] should be equal to\n      []"
+  AssertEqual g:vader_exception, "Unequal Lists\n      [1]\n      should be equal to\n      []"


### PR DESCRIPTION
This is useful with longer lists/dicts, where they line up then
visually.