### PR TITLE
Provide foldexpr for .vader files

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ Execute (syntax is good):
   AssertEqual SyntaxOf('0'), 'cNumber'
 ```
 
+Folding of .vader files
+-----------------------
+
+Folding of .vader files can be enabled by setting the the
+`g:vader_enable_folding` to 1. This will set `foldmethod` to `expr` and
+declare a corresponding fold expression.
+
 Setting up isolated testing environment
 ---------------------------------------
 

--- a/autoload/vader/folding.vim
+++ b/autoload/vader/folding.vim
@@ -1,0 +1,38 @@
+let s:regex_block_header  = '^\('
+let s:regex_block_header .=   'Given\|Do\|Execute\|Then\|Expect\|Before\|After'
+let s:regex_block_header .= '\)'
+let s:regex_block_header .= '\s\+'
+let s:regex_block_header .= '\w*'
+let s:regex_block_header .= '\s*'
+let s:regex_block_header .= '\%(([^()]\+)\)\?'
+let s:regex_block_header .= '[:;]'
+let s:regex_block_header .= '\s*'
+
+""
+" Foldexpression for vader files.
+"
+" This foldexpression folds the contents of all blocks.
+" The actual block headings are /not/ part of the fold to benefit from the
+" syntax highlighting, which is lost otherwise.
+function! vader#folding#foldExpr(lnum) abort
+  " each block header is level 0
+  if getline(a:lnum)     =~# s:regex_block_header
+    return 0
+  endif
+
+  " the content after each block header starts a new level 1 fold
+  if getline(a:lnum - 1) =~# s:regex_block_header
+    return '>1'
+  endif
+
+  " empty lines at the end of a block are not considered being part of the
+  " block and therefore not part of the fold
+  if getline(a:lnum) !~# '^\s*$'
+        \ && getline(nextnonblank(a:lnum + 1)) =~# s:regex_block_header
+    return 's1'
+  endif
+
+  " all other lines don't change the fold level
+  return '='
+endfunction
+

--- a/ftplugin/vader.vim
+++ b/ftplugin/vader.vim
@@ -37,6 +37,11 @@ setlocal iskeyword+=#
 let &l:commentstring = '" %s'
 let &l:comments      = 'sO:" -,mO:"  ,eO:"",:"'
 
+if get(g:, 'vader_enable_folding', 0) !=# 0
+  setlocal foldexpr=vader#folding#foldExpr(v:lnum)
+  setlocal foldmethod=expr
+endif
+
 nnoremap <buffer><silent> [[ :call search(b:vader_label, 'bW')<CR>
 nnoremap <buffer><silent> [] :call search(b:vader_eos, 'bW')<CR>
 
@@ -59,7 +64,7 @@ augroup vader_syntax
   " autocmd FileType <buffer> call vader#syntax#include(1, '$')
 augroup END
 
-let b:undo_ftplugin = 'setl sw< ts< sts< et< cms< isk<'
+let b:undo_ftplugin = 'setl sw< ts< sts< et< cms< isk< fde< fdm<'
       \ . ' | exe "au! vader_syntax * <buffer>"'
       \ . ' | unlet b:vader_label b:vader_eos'
 


### PR DESCRIPTION
The foldexpr will only be enabled if the newly introduced flag
`g:vader_enable_folding` is set to a non-zero value.