### PR TITLE
Rename "bundle" to "plugged" in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ the test. The simplest way to achieve this is to start Vim with a mini
 ```sh
 vim -Nu <(cat << EOF
 filetype off
-set rtp+=~/.vim/bundle/vader.vim
-set rtp+=~/.vim/bundle/vim-markdown
-set rtp+=~/.vim/bundle/vim-markdown/after
+set rtp+=~/.vim/plugged/vader.vim
+set rtp+=~/.vim/plugged/vim-markdown
+set rtp+=~/.vim/plugged/vim-markdown/after
 filetype plugin indent on
 syntax enable
 EOF) +Vader*

--- a/doc/vader.txt
+++ b/doc/vader.txt
@@ -338,9 +338,9 @@ as follows:
 >
     vim -Nu <(cat << EOF
     filetype off
-    set rtp+=~/.vim/bundle/vader.vim
-    set rtp+=~/.vim/bundle/vim-markdown
-    set rtp+=~/.vim/bundle/vim-markdown/after
+    set rtp+=~/.vim/plugged/vader.vim
+    set rtp+=~/.vim/plugged/vim-markdown
+    set rtp+=~/.vim/plugged/vim-markdown/after
     filetype plugin indent on
     syntax enable
     EOF) +Vader*


### PR DESCRIPTION
Update the README and helpfile to refer to the "plugged" directory
rather than the "bundle" directory when describing how to set up an
isolated testing environment, as the documentation elsewhere refers to
the vim-plug plugin manager, which uses a directory with this name.