### PR TITLE
Fix filetype names containing 's' lack proper highlight

### DIFF
--- a/syntax/vader.vim
+++ b/syntax/vader.vim
@@ -37,9 +37,9 @@ execute printf('syn region vaderTextRaw start=/\(;$\)\@<=/ end=/%s/ contained', 
 execute printf('syn region vaderCommandRaw start=/\(;$\)\@<=/ end=/%s/ contains=@vimSnippet contained', vader#syntax#_head())
 
 syn match vaderMessage /(\@<=.*)\@=/ contained contains=Todo
-syn match vaderGivenType /\(Given\s*\)\@<=[^;:()\s]\+/ contained
-syn match vaderExpectType /\(Expect\s*\)\@<=[^;:()\s]\+/ contained
-syn match vaderExecuteType /\(Execute\s*\)\@<=[^;:()\s]\+/ contained
+syn match vaderGivenType /\(Given\s*\)\@<=[^:; (]\+/ contained
+syn match vaderExpectType /\(Expect\s*\)\@<=[^:; (]\+/ contained
+syn match vaderExecuteType /\(Execute\s*\)\@<=[^:; (]\+/ contained
 
 syn match vaderComment /^["#].*/ contains=Todo
 syn match vaderSepCaret /^^.*/ contains=Todo


### PR DESCRIPTION
C#'s filetype is `cs`, but only the `c` in `cs` highlights in this example:

    Given cs (blah):

A character collection doesn't support escaping to expand character
classes, so [\s] is the same as [s]. Instead, we could use a named
character class:
    [^;:()[:space:]]
However, since \t isn't actually matched in the code it makes more sense
to do what the code does to indicate errors.


I tried to setup a test for this, but it seems that vader cannot test vader syntax:

    Given vader (blah):
      Given cs (blah):
        public class Example {}

    Execute:
      # this will fail even though the given text highlights in vim
      AssertEqual 'vaderGiven',  SyntaxAt(1, 1)
